### PR TITLE
fix: corrects handling for response payloads

### DIFF
--- a/src/Request.ts
+++ b/src/Request.ts
@@ -27,7 +27,7 @@ export interface IJSONRPCError {
 
 export interface IJSONRPCResponse {
   jsonrpc: "2.0";
-  id: string | number; // can also be null
+  id?: string | number; // can also be null
   result?: any;
   error?: IJSONRPCError;
 }

--- a/src/__mocks__/requestData.ts
+++ b/src/__mocks__/requestData.ts
@@ -36,7 +36,7 @@ export const generateMockNotificationResponse = (result: any, error?: any): req.
   };
 };
 
-export const generateMockErrorResponse = (id: number, data: any): req.IJSONRPCResponse => {
+export const generateMockErrorResponse = (id: number | undefined, data: any): req.IJSONRPCResponse => {
   return {
     id,
     jsonrpc: "2.0",

--- a/src/transports/TransportRequestManager.test.ts
+++ b/src/transports/TransportRequestManager.test.ts
@@ -52,6 +52,14 @@ describe("Transport Request Manager", () => {
     expect(err.message).toContain("Error message");
   });
 
+  it("should error on error response without id", () => {
+    const errPayload = reqData.generateMockErrorResponse(undefined, "haha");
+    delete errPayload.id;
+    const payload = JSON.stringify(errPayload);
+    const err = transportReqMan.resolveResponse(payload, false) as Error;
+    expect(err.message).toContain("Error message");
+  });
+
   it("should error on missing id to resolve and emit error", (done) => {
     transportReqMan.transportEventChannel.on("error", (e) => {
       expect(e.message).toContain("Could not resolve");
@@ -88,7 +96,7 @@ describe("Transport Request Manager", () => {
   });
 
   it("should emit response on response && resolve response", (done) => {
-    const res = reqData.generateMockResponse(1, "hello");
+    const res = reqData.generateMockResponse(1, false);
     // Add request to queue
     const prom = transportReqMan.addRequest({
       request: reqData.generateMockRequest(1, "foo", ["bar"]),

--- a/src/transports/TransportRequestManager.ts
+++ b/src/transports/TransportRequestManager.ts
@@ -88,7 +88,7 @@ export class TransportRequestManager {
     if (data instanceof Array) {
       payload = data;
     }
-    return payload.every((datum) => (datum.result || datum.error));
+    return payload.every((datum) => (datum.result !== undefined || datum.error !== undefined));
   }
 
   private processResult(payload: any, prom: IRequestPromise) {


### PR DESCRIPTION
This change is necessary to resolve payloads with
non undefined responses correctly. It includes a
expanded test for missing id on error response

fixes #75