### PR TITLE
 Add options to HTTPTransport constructor (#201 resubmitted)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   "clearMocks": true,
   "coverageDirectory": "../coverage",
-  "resetMocks": true,
+  // `resetMocks` resets reusable spies from __mocks__ to no-op implementation
+  // see: https://stackoverflow.com/a/63191062/2650622 for more details
+  "resetMocks": false,
   "restoreMocks": true,
   "rootDir": "./src",
   "testEnvironment": "jsdom",

--- a/src/__mocks__/isomorphic-fetch.ts
+++ b/src/__mocks__/isomorphic-fetch.ts
@@ -1,6 +1,6 @@
 import * as req from "./requestData";
 
-const Fetch = (url: string, options: any): Promise<any> => {
+const Fetch = jest.fn((url: string, options: any): Promise<any> => {
   if (url.match(/crash/)) {
     throw new Error("Random Segfault that crashes fetch");
   }
@@ -10,6 +10,6 @@ const Fetch = (url: string, options: any): Promise<any> => {
     },
   };
   return Promise.resolve(resultPromise);
-};
+});
 
 export default Fetch;


### PR DESCRIPTION
- add credentials and headers options to HTTPTransport that are passed
on to fetch
- disable resetMocks in jest.config.js as it resets reusable spies to
no-op implementation

Closes #200 open-rpc/inspector#172

Updated PR with signed commit