### PR TITLE
feat: add `close` method Client to close connection and cleanup event listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ const main = async () => {
 
 main().then(() => {
   console.log("DONE");
+  client.close();
 });
 
 ```

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,6 +1,7 @@
 import RequestManager from "./RequestManager";
 import { JSONRPCError } from "./Error";
 import { IClient, RequestArguments, NotificationArguments } from "./ClientInterface";
+import { IJSONRPCNotification } from "./Request";
 
 /**
  * OpenRPC Client JS is a browser-compatible JSON-RPC client with multiple transports and
@@ -80,12 +81,19 @@ class Client implements IClient {
     return this.requestManager.request(requestObject, true);
   }
 
-  public onNotification(callback: (data: any) => void) {
+  public onNotification(callback: (data: IJSONRPCNotification) => void) {
     this.requestManager.requestChannel.addListener("notification", callback);
   }
 
   public onError(callback: (data: JSONRPCError) => void) {
     this.requestManager.requestChannel.addListener("error", callback);
+  }
+
+  /**
+   * Close connection
+   */
+  public close() {
+    this.requestManager.close();
   }
 }
 

--- a/src/ClientInterface.ts
+++ b/src/ClientInterface.ts
@@ -1,3 +1,5 @@
+import { IJSONRPCNotification } from "./Request";
+
 interface Arguments {
   readonly method: string;
   readonly params?: readonly unknown[] | object;
@@ -12,4 +14,6 @@ export type JSONRPCMessage = RequestArguments | NotificationArguments;
 export interface IClient {
   request(args: RequestArguments): Promise<unknown>;
   notify(args: NotificationArguments): Promise<unknown>;
+  close(): void;
+  onNotification(callback: (data: IJSONRPCNotification) => void): void;
 }

--- a/src/RequestManager.ts
+++ b/src/RequestManager.ts
@@ -59,7 +59,9 @@ class RequestManager {
   }
 
   public close(): void {
+    this.requestChannel.removeAllListeners();
     this.transports.forEach((transport) => {
+      transport.unsubscribe();
       transport.close();
     });
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -61,4 +61,11 @@ describe("client-js", () => {
     c.stopBatch();
   });
 
+  describe("can close", () => {
+    const emitter = new EventEmitter();
+    const rm = new RequestManager([new EventEmitterTransport(emitter, "from1", "to1")]);
+    const c = new Client(rm);
+    c.close();
+  });
+
 });

--- a/src/transports/Transport.ts
+++ b/src/transports/Transport.ts
@@ -35,6 +35,14 @@ export abstract class Transport {
   public subscribe(event: TransportEventName, handler: ITransportEvents[TransportEventName]) {
     this.transportRequestManager.transportEventChannel.addListener(event, handler);
   }
+  public unsubscribe(event?: TransportEventName, handler?: ITransportEvents[TransportEventName]) {
+    if (!event) {
+      return this.transportRequestManager.transportEventChannel.removeAllListeners();
+    }
+    if (event && handler) {
+      this.transportRequestManager.transportEventChannel.removeListener(event, handler);
+    }
+  }
   protected parseData(data: JSONRPCRequestData) {
     if (data instanceof Array) {
       return data.map((batch) => batch.request.request);


### PR DESCRIPTION
 cleanup hopefully fixes some issues I'm having with lingering errors happening after creating multiple `new Client`s 🤞