### PR TITLE
fix: correct mem leaks caused by notification promise resolution

### DIFF
--- a/src/transports/PostMessageIframeTransport.ts
+++ b/src/transports/PostMessageIframeTransport.ts
@@ -1,5 +1,5 @@
 import { Transport } from "./Transport";
-import { JSONRPCRequestData, IJSONRPCData } from "../Request";
+import { JSONRPCRequestData, IJSONRPCData, getNotifications } from "../Request";
 
 class PostMessageIframeTransport extends Transport {
   public uri: string;
@@ -44,8 +44,10 @@ class PostMessageIframeTransport extends Transport {
 
   public async sendData(data: JSONRPCRequestData, timeout: number | null = 5000): Promise<any> {
     const prom = this.transportRequestManager.addRequest(data, null);
+    const notifications = getNotifications(data);
     if (this.frame) {
       this.frame.postMessage((data as IJSONRPCData).request, "*");
+      this.transportRequestManager.settlePendingRequest(notifications);
     }
     return prom;
   }

--- a/src/transports/PostMessageWindowTransport.ts
+++ b/src/transports/PostMessageWindowTransport.ts
@@ -1,5 +1,5 @@
 import { Transport } from "./Transport";
-import { JSONRPCRequestData, IJSONRPCData } from "../Request";
+import { JSONRPCRequestData, IJSONRPCData, getNotifications } from "../Request";
 
 const openPopup = (url: string) => {
   const width = 400;
@@ -53,8 +53,10 @@ class PostMessageTransport extends Transport {
 
   public async sendData(data: JSONRPCRequestData, timeout: number | undefined = 5000): Promise<any> {
     const prom = this.transportRequestManager.addRequest(data, null);
+    const notifications = getNotifications(data);
     if (this.frame) {
       this.frame.postMessage((data as IJSONRPCData).request, this.uri);
+      this.transportRequestManager.settlePendingRequest(notifications);
     }
     return prom;
   }

--- a/src/transports/TransportRequestManager.test.ts
+++ b/src/transports/TransportRequestManager.test.ts
@@ -153,6 +153,14 @@ describe("Transport Request Manager", () => {
     expect(err).toBeUndefined();
   });
 
+  it("should allow notification to clean up after itself", ()=> {
+    const req = { request: reqData.generateMockNotificationRequest("foobar",[]), internalID: 99 }
+    transportReqMan.addRequest(req, null);
+    expect(transportReqMan.isPendingRequest(99)).toEqual(true);
+    transportReqMan.settlePendingRequest([req]);
+    expect(transportReqMan.isPendingRequest(99)).toEqual(false);
+  })
+
   it("should emit notification on notification response", (done) => {
     transportReqMan.transportEventChannel.on("notification", (data: IJSONRPCNotificationResponse) => {
       expect(data.result).toEqual("hello");

--- a/src/transports/TransportRequestManager.ts
+++ b/src/transports/TransportRequestManager.ts
@@ -44,7 +44,15 @@ export class TransportRequestManager {
         return;
       }
       resolver.resolve();
+      // Notifications have no response and should clear their own pending requests
+      if(req.request.id === null || req.request.id === undefined){
+        delete this.pendingRequest[req.internalID];
+      }
     });
+  }
+
+  public isPendingRequest(id: string | number): boolean {
+    return this.pendingRequest.hasOwnProperty(id)
   }
 
   public resolveResponse(payload: string, emitError: boolean = true): TransportResponse {


### PR DESCRIPTION
Mem leaks were being caused by left over notification request promises
being left in the cache.

Notifications don't have responses to resolve, making it safe to just
clean up the pending results promises immediately upon settling/
aka resolving the promises after sending.

This change should only affect notification clean up, and no other
behaviors. In addition to this a method for checking the status
of a pending request was added.

fixes #294