### PR TITLE
feat: Ability to set custom fetch function as an option on HTTP transport

### DIFF
--- a/src/transports/HTTPTransport.ts
+++ b/src/transports/HTTPTransport.ts
@@ -8,14 +8,14 @@ type CredentialsOption = "omit" | "same-origin" | "include"
 interface HTTPTransportOptions {
   credentials?: CredentialsOption
   headers?: Record<string, string>
-  fetch?: any
+  fetch?: () => {}
 }
 
 class HTTPTransport extends Transport {
   public uri: string;
   private readonly credentials?: CredentialsOption;
   private readonly headers: Headers;
-  private readonly fetch: Function;
+  private readonly fetch: () => {};
   constructor(uri: string, options?: HTTPTransportOptions) {
     super();
     this.uri = uri;

--- a/src/transports/HTTPTransport.ts
+++ b/src/transports/HTTPTransport.ts
@@ -8,17 +8,20 @@ type CredentialsOption = "omit" | "same-origin" | "include"
 interface HTTPTransportOptions {
   credentials?: CredentialsOption
   headers?: Record<string, string>
+  fetch?: Function
 }
 
 class HTTPTransport extends Transport {
   public uri: string;
   private readonly credentials?: CredentialsOption;
-  private readonly headers: Headers
+  private readonly headers: Headers;
+  private readonly fetch: Function;
   constructor(uri: string, options?: HTTPTransportOptions) {
     super();
     this.uri = uri;
     this.credentials = options && options.credentials;
-    this.headers = HTTPTransport.setupHeaders(options && options.headers)
+    this.headers = HTTPTransport.setupHeaders(options && options.headers);
+    this.fetch = (options && options.fetch) || fetch;
   }
   public connect(): Promise<any> {
     return Promise.resolve();
@@ -29,7 +32,7 @@ class HTTPTransport extends Transport {
     const notifications = getNotifications(data);
     const batch = getBatchRequests(data);
     try {
-      const result = await fetch(this.uri, {
+      const result = await this.fetch(this.uri, {
         method: "POST",
         headers: this.headers,
         body: JSON.stringify(this.parseData(data)),

--- a/src/transports/HTTPTransport.ts
+++ b/src/transports/HTTPTransport.ts
@@ -8,14 +8,14 @@ type CredentialsOption = "omit" | "same-origin" | "include"
 interface HTTPTransportOptions {
   credentials?: CredentialsOption
   headers?: Record<string, string>
-  fetch?: () => {}
+  fetch?: any
 }
 
 class HTTPTransport extends Transport {
   public uri: string;
   private readonly credentials?: CredentialsOption;
   private readonly headers: Headers;
-  private readonly fetch: () => {};
+  private readonly fetch: any;
   constructor(uri: string, options?: HTTPTransportOptions) {
     super();
     this.uri = uri;

--- a/src/transports/HTTPTransport.ts
+++ b/src/transports/HTTPTransport.ts
@@ -8,7 +8,7 @@ type CredentialsOption = "omit" | "same-origin" | "include"
 interface HTTPTransportOptions {
   credentials?: CredentialsOption
   headers?: Record<string, string>
-  fetch?: Function
+  fetch?: any
 }
 
 class HTTPTransport extends Transport {


### PR DESCRIPTION
I am implementing a native app with React Native and use OAuth for authentication. To facilitate token refresh on demand, I am using https://github.com/badgateway/fetch-mw-oauth2 which provides a fetch middleware to retry failed requests after refreshing access tokens.

This pattern works well when clients allow setting a custom fetch function, [e.g. in the case of Orbit.js](https://github.com/orbitjs/orbit/blob/ecd1b6c64d2832ef463cd57ad64b9c7db128ff55/packages/%40orbit/jsonapi/src/jsonapi-request-processor.ts#L164) (a json:api client.)

I am not really much of a TypeScript developer but I have worked this out locally and it "seems to work." Hoping this could be an easy/backwards and forwards compatible change that would make this library even better. Thanks!